### PR TITLE
fix(versions): update Activiti/activiti-cloud-modeling versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <activiti-cloud-modeling-dependencies.version>7.1.387</activiti-cloud-modeling-dependencies.version>
+    <activiti-cloud-modeling-dependencies.version>7.1.401</activiti-cloud-modeling-dependencies.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.cloud.modeling:activiti-cloud-modeling-dependencies` to: `7.1.401`